### PR TITLE
Remove Timezone Parameter from Numerical Timeseries

### DIFF
--- a/cwms/timeseries/timeseries.py
+++ b/cwms/timeseries/timeseries.py
@@ -101,10 +101,13 @@ class CwmsTs(_CwmsBase):
             begin: datetime, optional, default is None 
                 Start of the time window for data to be included in the response. If this field is 
                 not specified, any required time window begins 24 hours prior to the specified 
-                or default end time.
+                or default end time. Any timezone information should be passed within the datetime
+                object. If no timezone information is given, default will be UTC.
             end: datetime, optional, default is None
                 End of the time window for data to be included in the response. If this field is 
-                not specified, any required time window ends at the current time.
+                not specified, any required time window ends at the current time. Any timezone
+                information should be passed within the datetime object. If no timezone information
+                is given, default will be UTC.
             page_size: int, optional, default is 5000000: Sepcifies the number of records to obtain in
                 a single call.
 

--- a/cwms/timeseries/timeseries.py
+++ b/cwms/timeseries/timeseries.py
@@ -76,7 +76,6 @@ class CwmsTs(_CwmsBase):
         datum: str = None,
         begin: datetime = None,
         end: datetime = None,
-        timezone: str = None,
         page_size: int = 500000,
     ) -> pd.DataFrame:
         """Retrieves time series data from a specified time series and time window.  
@@ -106,10 +105,7 @@ class CwmsTs(_CwmsBase):
             end: datetime, optional, default is None
                 End of the time window for data to be included in the response. If this field is 
                 not specified, any required time window ends at the current time.
-            timezone: str, optional, default is None: 
-                Specifies the time zone of the values of the begin and end fields. UTC is the default. 
-                This value does not impact the values in response.  response is always in UTC.
-            page_size: int, optional, default is 5000000: Sepcifies the number of records to obtain in 
+            page_size: int, optional, default is 5000000: Sepcifies the number of records to obtain in
                 a single call.
 
         Returns
@@ -119,7 +115,7 @@ class CwmsTs(_CwmsBase):
         """
 
         responce = CwmsTs.retrieve_ts_json(
-            self, tsId, office_id, unit, datum, begin, end, timezone, page_size
+            self, tsId, office_id, unit, datum, begin, end, page_size
         )
 
         df = return_df(responce, dict_key=['values'])
@@ -134,7 +130,6 @@ class CwmsTs(_CwmsBase):
         datum: str = None,
         begin: datetime = None,
         end: datetime = None,
-        timezone: str = None,
         page_size: int = 500000,
         version_date: datetime = None,
     ) -> dict:
@@ -161,13 +156,13 @@ class CwmsTs(_CwmsBase):
             begin: datetime, optional, default is None 
                 Start of the time window for data to be included in the response. If this field is 
                 not specified, any required time window begins 24 hours prior to the specified 
-                or default end time.
+                or default end time. Any timezone information should be passed within the datetime
+                object. If no timezone information is given, default will be UTC.
             end: datetime, optional, default is None
                 End of the time window for data to be included in the response. If this field is 
-                not specified, any required time window ends at the current time.
-            timezone: str, optional, default is None: 
-                Specifies the time zone of the values of the begin and end fields. UTC is the default. 
-                This value does not impact the values in response.  response is always in UTC.
+                not specified, any required time window ends at the current time. Any timezone
+                information should be passed within the datetime object. If no timezone information
+                is given, default will be UTC.
             page_size: int, optional, default is 5000000: Sepcifies the number of records to obtain in 
                 a single call.
             version_date: datetime, optional, default is None
@@ -183,13 +178,13 @@ class CwmsTs(_CwmsBase):
         end_point = CwmsTs._TIMESERIES_ENDPOINT
 
         if begin is not None:
-            begin = begin.strftime('%Y-%m-%dT%H:%M:%S')
+            begin = begin.isoformat()
 
         if end is not None:
-            end = end.strftime('%Y-%m-%dT%H:%M:%S')
+            end = end.isoformat()
 
         if version_date is not None:
-            version_date = version_date.strftime('%Y-%m-%dT%H:%M:%S')
+            version_date = version_date.isoformat()
 
         params = {
             constants.OFFICE_PARAM: office_id,
@@ -198,7 +193,6 @@ class CwmsTs(_CwmsBase):
             constants.DATUM: datum,
             constants.BEGIN: begin,
             constants.END: end,
-            constants.TIMEZONE: timezone,
             constants.PAGE_SIZE: page_size,
             constants.VERSION_DATE: version_date,
         }
@@ -211,7 +205,6 @@ class CwmsTs(_CwmsBase):
     def write_ts(
         self,
         data,
-        timezone: str = None,
         create_as_ltrs: bool = False,
         store_rule: str = None,
         override_protection: bool = False,
@@ -233,10 +226,6 @@ class CwmsTs(_CwmsBase):
                     1   2023-12-20T15:00:00.000-05:00  99.8           0
                     2   2023-12-20T15:15:00.000-05:00  98.5           0
                     3   2023-12-20T15:30:00.000-05:00  98.5           0
-            timezone: str, optional, default is None)
-                Specifies the time zone of the version-date field (unless otherwise specified). If this field is 
-                not specified, the default time zone of UTC shall be used.  Ignored if version-date was specified 
-                with offset and timezone.
             create_as_ltrs: bool, optional, defualt is False
                 Flag indicating if timeseries should be created as Local Regular Time Series.
             store_rule: str, optional, default is None: 
@@ -256,7 +245,6 @@ class CwmsTs(_CwmsBase):
 
         end_point = CwmsTs._TIMESERIES_ENDPOINT
         params = {
-            constants.TIMEZONE: timezone,
             'create-as-lrts': create_as_ltrs,
             'store-rule': store_rule,
             'override-protection': override_protection,

--- a/examples/cwms_versioned_ts_examples.py
+++ b/examples/cwms_versioned_ts_examples.py
@@ -3,7 +3,7 @@
 #  All Rights Reserved.  USACE PROPRIETARY/CONFIDENTIAL.
 #  Source may not be released without written approval from HEC
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytz
 
@@ -35,8 +35,8 @@ def run_versioned_ts_examples():
           "horizontal-datum": "NAD83",
           "vertical-datum": "NGVD29",
           "elevation": 320.04,
-          "bounding-office-id": "SPK",
-          "office-id": "SPK"
+          "bounding-office-id": "SWT",
+          "office-id": "SWT"
         }
         '''
     headers = {
@@ -52,25 +52,25 @@ def run_versioned_ts_examples():
           "office-id": "SWT",
           "name": "TEST.Flow.Inst.1Hour.0.MockTest",
           "units": "CFS",
-          "version-date": "2021-06-20T08:00:00-0000[UTC]",
+          "version-date": "2021-06-20T08:00:00-0700[-07:00]",
           "values": [
             [
-              1209654000000,
+              1209679200000,
               4,
               0
             ],
             [
-              1209657600000,
+              1209682800000,
               4,
               0
             ],
             [
-              1209661200000,
+              1209686400000,
               4,
               0
             ],
             [
-              1209664800000,
+              1209690000000,
               3,
               0
             ]
@@ -78,15 +78,17 @@ def run_versioned_ts_examples():
         }
         ''')
     print(f"Storing versioned ts {versioned_ts['name']}")
-    ts_api.write_ts(data=versioned_ts, timezone="UTC")
+    ts_api.write_ts(data=versioned_ts)
 
-    timezone = "UTC"
-    begin = datetime(2008, 5, 1, 15, 0, 0)
-    end = datetime(2008, 5, 1, 18, 0, 0)
-    version_date = datetime(2021, 6, 20, 8, 0, 0)
+    timezone = pytz.timezone("US/Pacific")
+    begin = timezone.localize(datetime(2008, 5, 1, 15, 0, 0))
+    print()
+    end = timezone.localize(datetime(2008, 5, 1, 18, 0, 0))
+    version_date = timezone.localize(datetime(2021, 6, 20, 8, 0, 0))
+    print(version_date)
 
     versioned_ts_dict = ts_api.retrieve_ts_json(
-        tsId=versioned_ts['name'], office_id="SWT", begin=begin, end=end, version_date=version_date, timezone=timezone)
+        tsId=versioned_ts['name'], office_id="SWT", begin=begin, end=end, version_date=version_date)
     print(versioned_ts_dict)
 
 def run_unversioned_ts_examples():
@@ -110,8 +112,8 @@ def run_unversioned_ts_examples():
           "horizontal-datum": "NAD83",
           "vertical-datum": "NGVD29",
           "elevation": 320.04,
-          "bounding-office-id": "SPK",
-          "office-id": "SPK"
+          "bounding-office-id": "SWT",
+          "office-id": "SWT"
         }
         '''
     headers = {
@@ -129,22 +131,22 @@ def run_unversioned_ts_examples():
           "units": "CFS",
           "values": [
             [
-              1209654000000,
+              1209679200000,
               4,
               0
             ],
             [
-              1209657600000,
+              1209682800000,
               4,
               0
             ],
             [
-              1209661200000,
+              1209686400000,
               4,
               0
             ],
             [
-              1209664800000,
+              1209690000000,
               3,
               0
             ]
@@ -152,14 +154,14 @@ def run_unversioned_ts_examples():
         }
         ''')
     print(f"Storing unversioned ts {unversioned_ts['name']}")
-    ts_api.write_ts(data=unversioned_ts, timezone="UTC")
+    ts_api.write_ts(data=unversioned_ts)
 
-    timezone = "UTC"
-    begin = datetime(2008, 5, 1, 15, 0, 0)
-    end = datetime(2008, 5, 1, 18, 0, 0)
+    timezone = pytz.timezone("US/Pacific")
+    begin = timezone.localize(datetime(2008, 5, 1, 15, 0, 0))
+    end = timezone.localize(datetime(2008, 5, 1, 18, 0, 0))
 
     unversioned_ts_dict = ts_api.retrieve_ts_json(
-        tsId=unversioned_ts['name'], office_id="SWT", begin=begin, end=end, timezone=timezone)
+        tsId=unversioned_ts['name'], office_id="SWT", begin=begin, end=end)
     print(unversioned_ts_dict)
 
 def run_max_agg_ts_examples():
@@ -183,8 +185,8 @@ def run_max_agg_ts_examples():
               "horizontal-datum": "NAD83",
               "vertical-datum": "NGVD29",
               "elevation": 320.04,
-              "bounding-office-id": "SPK",
-              "office-id": "SPK"
+              "bounding-office-id": "SWT",
+              "office-id": "SWT"
             }
             '''
     headers = {
@@ -200,20 +202,20 @@ def run_max_agg_ts_examples():
           "office-id": "SWT",
           "name": "TEST.Flow.Inst.1Hour.0.MockTestMaxAgg",
           "units": "CFS",
-          "version-date": "2021-06-20T08:00:00-0000[UTC]",
+          "version-date": "2021-06-20T08:00:00-0700[-07:00]",
           "values": [
             [
-              1209654000000,
+              1209679200000,
               4,
               0
             ],
             [
-              1209657600000,
+              1209682800000,
               3,
               0
             ],
             [
-              1209661200000,
+              1209686400000,
               2,
               0
             ]
@@ -221,7 +223,7 @@ def run_max_agg_ts_examples():
         }
         ''')
     print(f"Storing versioned ts 1 {versioned_ts['name']}")
-    ts_api.write_ts(data=versioned_ts, timezone="UTC")
+    ts_api.write_ts(data=versioned_ts)
 
     versioned_ts2 = json.loads(
         '''
@@ -229,10 +231,10 @@ def run_max_agg_ts_examples():
           "office-id": "SWT",
           "name": "TEST.Flow.Inst.1Hour.0.MockTestMaxAgg",
           "units": "CFS",
-          "version-date": "2021-06-21T08:00:00-0000[UTC]",
+          "version-date": "2021-06-21T08:00:00-0000[-07:00]",
           "values": [
             [
-              1209664800000,
+              1209690000000,
               1,
               0
             ]
@@ -241,14 +243,14 @@ def run_max_agg_ts_examples():
         ''')
 
     print(f"Storing versioned ts 2 {versioned_ts2['name']}")
-    ts_api.write_ts(data=versioned_ts2, timezone="UTC")
+    ts_api.write_ts(data=versioned_ts2)
 
-    timezone = "UTC"
-    begin = datetime(2008, 5, 1, 15, 0, 0)
-    end = datetime(2008, 5, 1, 18, 0, 0)
+    timezone = pytz.timezone("US/Pacific")
+    begin = timezone.localize(datetime(2008, 5, 1, 15, 0, 0))
+    end = timezone.localize(datetime(2008, 5, 1, 18, 0, 0))
 
     max_agg_ts_dict = ts_api.retrieve_ts_json(
-        tsId=versioned_ts['name'], office_id="SWT", begin=begin, end=end, timezone=timezone)
+        tsId=versioned_ts['name'], office_id="SWT", begin=begin, end=end)
     print(max_agg_ts_dict)
 
 if __name__ == "__main__":

--- a/tests/timeseries/timeseries_test.py
+++ b/tests/timeseries/timeseries_test.py
@@ -24,20 +24,24 @@ class TestTs(unittest.TestCase):
     def test_retrieve_unversioned_ts_json_default(self, m):
         m.get(
             f"{TestTs._MOCK_ROOT}"
-            "/timeseries?office=SWT&name=TEST.Text.Inst.1Hour.0.MockTest&"
+            "/timeseries?office=SWT&"
+            "name=TEST.Text.Inst.1Hour.0.MockTest&"
             "unit=EN&"
-            "begin=2008-05-01T15%3A00%3A00&"
-            "end=2008-05-01T17%3A00%3A00&"
-            "page-size=500000&",
+            "begin=2008-05-01T15%3A00%3A00%2B00%3A00&"
+            "end=2008-05-01T17%3A00%3A00%2B00%3A00&"
+            "page-size=500000"
+            ,
             json=_UNVERS_TS_JSON)
         cwms_ts = CwmsTs(CwmsApiSession(TestTs._MOCK_ROOT))
         timeseries_id = "TEST.Text.Inst.1Hour.0.MockTest"
         office_id = "SWT"
-        timezone = "UTC"
-        begin = datetime(2008, 5, 1, 15, 0, 0)
-        end = datetime(2008, 5, 1, 17, 0, 0)
 
-        timeseries = cwms_ts.retrieve_ts_json(tsId=timeseries_id, office_id=office_id, begin=begin, end=end, timezone=timezone)
+        # explicitly format begin and end dates with default timezone as an example
+        timezone = pytz.timezone("UTC")
+        begin = timezone.localize(datetime(2008, 5, 1, 15, 0, 0))
+        end = timezone.localize(datetime(2008, 5, 1, 17, 0, 0))
+
+        timeseries = cwms_ts.retrieve_ts_json(tsId=timeseries_id, office_id=office_id, begin=begin, end=end)
         self.assertEqual(_UNVERS_TS_JSON, timeseries)
 
     @requests_mock.Mocker()
@@ -55,22 +59,25 @@ class TestTs(unittest.TestCase):
     def test_retrieve_versioned_ts_json_default(self, m):
         m.get(
             f"{TestTs._MOCK_ROOT}"
-            "/timeseries?office=SWT&name=TEST.Text.Inst.1Hour.0.MockTest&"
+            "/timeseries?office=SWT&"
+            "name=TEST.Text.Inst.1Hour.0.MockTest&"
             "unit=EN&"
-            "begin=2008-05-01T15%3A00%3A00&"
-            "end=2008-05-01T17%3A00%3A00&"
+            "begin=2008-05-01T15%3A00%3A00%2B00%3A00&"
+            "end=2008-05-01T17%3A00%3A00%2B00%3A00&"
             "page-size=500000&"
-            "version-date=2021-06-20T08%3A00%3A00",
+            "version-date=2021-06-20T08%3A00%3A00%2B00%3A00",
             json=_VERS_TS_JSON)
         cwms_ts = CwmsTs(CwmsApiSession(TestTs._MOCK_ROOT))
         timeseries_id = "TEST.Text.Inst.1Hour.0.MockTest"
         office_id = "SWT"
-        timezone ="UTC"
-        begin = datetime(2008, 5, 1, 15, 0, 0)
-        end = datetime(2008, 5, 1, 17, 0, 0)
-        version_date = datetime(2021, 6, 20, 8, 0, 0)
 
-        timeseries = cwms_ts.retrieve_ts_json(tsId=timeseries_id, office_id=office_id, begin=begin, end=end, version_date=version_date, timezone=timezone)
+        # explicitly format begin and end dates with default timezone as an example
+        timezone = pytz.timezone("UTC")
+        begin = timezone.localize(datetime(2008, 5, 1, 15, 0, 0))
+        end = timezone.localize(datetime(2008, 5, 1, 17, 0, 0))
+        version_date = timezone.localize(datetime(2021, 6, 20, 8, 0, 0))
+
+        timeseries = cwms_ts.retrieve_ts_json(tsId=timeseries_id, office_id=office_id, begin=begin, end=end, version_date=version_date)
         self.assertEqual(_VERS_TS_JSON, timeseries)
 
     @requests_mock.Mocker()


### PR DESCRIPTION
This pull request removes the timezone parameter from retrieve and write timeseries functions. Having a timezone parameter along with the possibility to include timezone information within the begin and end datetime objects can cause ambiguity to the intended timezone value. Due to this ambiguity, the timezone parameter has been removed so that all begin and end timezone information is held within the begin and end datetime variables.