### PR TITLE
Turbine Changes Require List POST

### DIFF
--- a/cwms/api.py
+++ b/cwms/api.py
@@ -309,7 +309,7 @@ def post(
     # post requires different headers than get for
     headers = {"accept": "*/*", "Content-Type": api_version_text(api_version)}
 
-    if isinstance(data, dict):
+    if isinstance(data, dict) or isinstance(data, list):
         data = json.dumps(data)
 
     response = SESSION.post(endpoint, params=params, headers=headers, data=data)
@@ -349,7 +349,7 @@ def patch(
     if data is None:
         response = SESSION.patch(endpoint, params=params, headers=headers)
     else:
-        if isinstance(data, dict):
+        if isinstance(data, dict) or isinstance(data, list):
             data = json.dumps(data)
         response = SESSION.patch(endpoint, params=params, headers=headers, data=data)
     response.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cwms-python"
 
-version = "0.5.5"
+version = "0.5.6"
 
 packages = [
     { include = "cwms" },


### PR DESCRIPTION
The endpoint 
`/swt-data/projects/{office}/{name}/turbine-changes`

Requires a List to store. 

We attempted to store using a dictionary/Object and got a serialization error. 

Error :
```
Cannot deserialize value of type `java.util.ArrayList<cwms.cda.data.dto.location.kind.TurbineChange>` from Object value (token `JsonToken.START_OBJECT`)
```
Suggesting it is trying to use and Array but an Object was provided


In this PR I update the post and patch in the API methods to allow for a `List` to be provided. 

I confirmed this works by manually editing the library on @AndySWT computer and we successfully saved a turbine change. 

I did consider putting `JSON` as the type check, but that appears to be of type `[dict, Any]` and could cause issues. 
