### PR TITLE
improve multi_timeseries call

### DIFF
--- a/cwms/api.py
+++ b/cwms/api.py
@@ -61,7 +61,6 @@ SESSION = sessions.BaseUrlSession(base_url=API_ROOT)
 adapter = adapters.HTTPAdapter(
     pool_connections=100, pool_maxsize=100, max_retries=retry_strategy
 )
-# adapter = adapters.HTTPAdapter(max_retries=retry_strategy)
 SESSION.mount("https://", adapter)
 
 
@@ -140,7 +139,6 @@ def init_session(
             pool_maxsize=pool_connections,
             max_retries=retry_strategy,
         )
-        # adapter = adapters.HTTPAdapter(max_retries=retry_strategy)
         SESSION.mount("https://", adapter)
     if api_key:
         logging.debug(f"Setting authorization key: api_key={api_key}")

--- a/cwms/api.py
+++ b/cwms/api.py
@@ -34,6 +34,7 @@ from typing import Any, Optional, cast
 from requests import Response, adapters
 from requests_toolbelt import sessions  # type: ignore
 from requests_toolbelt.sessions import BaseUrlSession  # type: ignore
+from urllib3.util.retry import Retry
 
 from cwms.cwms_types import JSON, RequestParams
 
@@ -42,8 +43,25 @@ API_ROOT = "https://cwms-data.usace.army.mil/cwms-data/"
 API_VERSION = 2
 
 # Initialize a non-authenticated session with the default root URL and set default pool connections.
+
+retry_strategy = Retry(
+    total=6,
+    backoff_factor=0.5,
+    status_forcelist=[
+        403,
+        429,
+        500,
+        502,
+        503,
+        504,
+    ],  # Example: also retry on these HTTP status codes
+    allowed_methods=["GET", "PUT", "POST", "PATCH", "DELETE"],  # Methods to retry
+)
 SESSION = sessions.BaseUrlSession(base_url=API_ROOT)
-adapter = adapters.HTTPAdapter(pool_connections=100, pool_maxsize=100)
+adapter = adapters.HTTPAdapter(
+    pool_connections=100, pool_maxsize=100, max_retries=retry_strategy
+)
+# adapter = adapters.HTTPAdapter(max_retries=retry_strategy)
 SESSION.mount("https://", adapter)
 
 
@@ -118,8 +136,11 @@ def init_session(
         logging.debug(f"Initializing root URL: api_root={api_root}")
         SESSION = sessions.BaseUrlSession(base_url=api_root)
         adapter = adapters.HTTPAdapter(
-            pool_connections=pool_connections, pool_maxsize=pool_connections
+            pool_connections=pool_connections,
+            pool_maxsize=pool_connections,
+            max_retries=retry_strategy,
         )
+        # adapter = adapters.HTTPAdapter(max_retries=retry_strategy)
         SESSION.mount("https://", adapter)
     if api_key:
         logging.debug(f"Setting authorization key: api_key={api_key}")

--- a/cwms/timeseries/timeseries.py
+++ b/cwms/timeseries/timeseries.py
@@ -155,7 +155,7 @@ def get_timeseries(
             not specified, any required time window ends at the current time. Any timezone
             information should be passed within the datetime object. If no timezone information
             is given, default will be UTC.
-        page_size: int, optional, default is 5000000: Specifies the number of records to obtain in
+        page_size: int, optional, default is 300000: Specifies the number of records to obtain in
             a single call.
         version_date: datetime, optional, default is None
             Version date of time series values being requested. If this field is not specified and

--- a/tests/timeseries/timeseries_test.py
+++ b/tests/timeseries/timeseries_test.py
@@ -148,7 +148,7 @@ def test_get_timeseries_unversioned_default(requests_mock):
         "unit=EN&"
         "begin=2008-05-01T15%3A00%3A00%2B00%3A00&"
         "end=2008-05-01T17%3A00%3A00%2B00%3A00&"
-        "page-size=500000",
+        "page-size=300000",
         json=_UNVERS_TS_JSON,
     )
 
@@ -177,7 +177,7 @@ def test_get_empty_ts_df(requests_mock):
         "unit=EN&"
         "begin=2008-05-01T15%3A00%3A00%2B00%3A00&"
         "end=2008-05-01T17%3A00%3A00%2B00%3A00&"
-        "page-size=500000&"
+        "page-size=300000&"
         "trim=true",
         json=_EMPTY_TS_JSON,
     )
@@ -306,7 +306,7 @@ def test_get_multi_timeseries_default(requests_mock):
         "unit=EN&"
         "begin=2008-05-01T15%3A00%3A00%2B00%3A00&"
         "end=2008-05-01T17%3A00%3A00%2B00%3A00&"
-        "page-size=500000&"
+        "page-size=300000&"
         "version-date=2021-06-20T08%3A00%3A00%2B00%3A00",
         json=_VERS_TS_JSON,
     )
@@ -318,7 +318,7 @@ def test_get_multi_timeseries_default(requests_mock):
         "unit=EN&"
         "begin=2008-05-01T15%3A00%3A00%2B00%3A00&"
         "end=2008-05-01T17%3A00%3A00%2B00%3A00&"
-        "page-size=500000",
+        "page-size=300000",
         json=_UNVERS_TS_JSON,
     )
 
@@ -362,7 +362,7 @@ def test_get_timeseries_versioned_default(requests_mock):
         "unit=EN&"
         "begin=2008-05-01T15%3A00%3A00%2B00%3A00&"
         "end=2008-05-01T17%3A00%3A00%2B00%3A00&"
-        "page-size=500000&"
+        "page-size=300000&"
         "version-date=2021-06-20T08%3A00%3A00%2B00%3A00",
         json=_VERS_TS_JSON,
     )


### PR DESCRIPTION
- update to improve multi_timeseries call to use concurrent.futures instead of threading.
- Added retries for all API calls if connection fails. Retries set to 6.  