### PR TITLE
Add ability to create CLI scripts for cwms-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,59 @@ endpoint implementation.
 ## Contributing
 
 Please view the contribution documentation here: [CONTRIBUTING.md]
+
+
+## CLI Utilities
+
+You can invoke various utilities from cwms-python. 
+
+To see a list of utilities run:
+    `cwms`
+
+Then to run a utility's help you can run:
+    `cwms store_file` or `cwms store_file -h`
+    *This will show the arguments*
+
+### Storing Files
+
+You can store files from your local disk to the blob endpoint with this script:
+`cwms store_file`
+
+And example call for this might be:
+`cwms store_file "C:/path/to/MY_TEXT FILE.shef" MY_TEXT_FILE.SHEF`
+*NOTE* Blobs Ids get stored all uppercase even if the output name has lowercase in it!
+
+The `store_file` utility expects you to have environment variables set or via the CLI. 
+
+#### Environment Variable Options  
+
+- `OFFICE`
+- `CDA_API_ROOT`  
+- `CDA_API_KEY`  
+- `LOG_LEVEL` (Options: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")  
+
+#### Arguments
+
+*Required*
+- input_file 
+- output_id  
+
+*Optional*
+
+- Help [-h] 
+- Blob Description [--description DESCRIPTION] 
+- File Media Type [--media-type MEDIA_TYPE] - [Mime-Type Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types)
+- 3/4 Letter Office ID [--office-id OFFICE_ID] 
+- CDA Endpoint [--api-root CDA_API_ROOT] (Overrides Env Var)
+- CDA API KEY [--api-key CDA_API_KEY] (Overrides Env Var)
+- [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}] 
+
+**Some args become required if their environment variable is not set!**
+
+### Environment Variables
+
+The common environment variables names agreed upon by the CWMS community are:  
+- `OFFICE="SWT"`  
+- `ENVIRONMENT="dev"` (or "test" or "prod")  
+- `CDA_API_ROOT="https://cwms-data.usace.army.mil/cwms-data"` (or your T7 URL, or Dev, or Test)  
+- `CDA_API_KEY="LongKeyFromAuthEndpointInCDA"`  

--- a/cwms/utils/cli/__main__.py
+++ b/cwms/utils/cli/__main__.py
@@ -1,0 +1,57 @@
+import argparse
+import importlib
+import os
+import sys
+from pathlib import Path
+
+
+def discover_commands():
+    """
+    Discovers all Python files in cwms/utils/cli/ and returns a dict of command -> module
+    """
+    base_dir = Path(__file__).parent
+    commands = {}
+
+    for file in os.listdir(base_dir):
+        # Only call .py scripts and ignore any dunder files (i.e. starts with _)
+        if file.endswith(".py") and not file.startswith("_"):
+            cmd = file[:-3]
+            mod_path = f"cwms.utils.cli.{cmd}"
+            commands[cmd] = mod_path
+
+    return commands
+
+
+def main():
+    commands = discover_commands()
+
+    parser = argparse.ArgumentParser(
+        prog="cwms", description="CWMS-Python CLI Utilities"
+    )
+    parser.add_argument("command", choices=commands.keys(), help="The script to run")
+    parser.add_argument(
+        "args", nargs=argparse.REMAINDER, help="Arguments to pass to the script"
+    )
+
+    # Ensures that at least one argument (the command) is provided otherwise provides the cwms help
+    if len(sys.argv) < 2:
+        parser.print_help()
+        sys.exit(1)
+
+    parsed = parser.parse_args()
+    command = parsed.command
+    args = parsed.args
+
+    # Loads the selected command module and calls its main function
+    try:
+        mod = importlib.import_module(commands[command])
+        if hasattr(mod, "main"):
+            mod.main(args)
+        else:
+            print(
+                f"The module {commands[command]} does not have a 'main(args)' function."
+            )
+            sys.exit(2)
+    except ImportError as e:
+        print(f"Failed to import command module '{command}': {e}")
+        sys.exit(1)

--- a/cwms/utils/cli/store_file.py
+++ b/cwms/utils/cli/store_file.py
@@ -1,0 +1,164 @@
+import argparse
+import base64
+import json
+import logging
+import mimetypes
+import os
+import sys
+from datetime import datetime
+from logging.handlers import RotatingFileHandler
+
+import requests
+
+import cwms.api as api
+import cwms.catalog.blobs as blobs
+import cwms.timeseries.timeseries as timeseries
+
+# Windows SSL Error?
+# Run: pip install pip_system_certs
+
+# Setup logging
+home_dir = os.path.expanduser("~")
+LOG_DIR = os.path.join(home_dir, "logs")
+if not os.path.exists(LOG_DIR):
+    os.makedirs(LOG_DIR)
+
+log_path = os.path.join(LOG_DIR, "cwms_blob_uploader.log")
+
+
+def get_media_type(file_path: str) -> str:
+    mime_type, _ = mimetypes.guess_type(file_path)
+    return mime_type or "application/octet-stream"
+
+
+def main(args: list[str] | None = None):
+    if args is None:
+        args = sys.argv[1:]
+
+    # Skip the subcommand if it's passed in
+    if len(args) > 0 and args[0] == "store_file":
+        args = args[1:]
+    parser = argparse.ArgumentParser(description="Upload a file as blob to CWMS.")
+    # TODO: Should this also take a web url for input files?
+    parser.add_argument("input_file", help="Path to the input file")
+    parser.add_argument("output_id", help="ID to use for the stored blob")
+    parser.add_argument(
+        "--description", help="Optional description of the file", default=None
+    )
+    parser.add_argument(
+        "--media-type", help="Optional media type of the file", default=None
+    )
+    parser.add_argument(
+        "--office-id",
+        help="Optional office ID",
+        default=os.getenv("OFFICE")
+        or os.getenv("OFFICE_ID")
+        or os.getenv("CDA_OFFICE"),
+    )
+    parser.add_argument(
+        "--api-root",
+        help="API root URL",
+        dest="api_root",
+        required=False,
+        default=os.getenv("APIROOT")
+        or os.getenv("API_ROOT")
+        or os.getenv("CDA_HOST")
+        or os.getenv("CDA_API_ROOT"),
+    )
+    parser.add_argument(
+        "--api-key",
+        help="API key",
+        dest="api_key",
+        required=False,
+        default=os.getenv("APIKEY") or os.getenv("API_KEY") or os.getenv("CDA_API_KEY"),
+    )
+    parser.add_argument(
+        "--log-level",
+        help="Sets the log output level",
+        default=os.getenv("LOG_LEVEL", "INFO"),
+        required=False,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+    )
+
+    args = parser.parse_args(args)
+
+    # Verify required arguments
+    if not args.input_file or not os.path.isfile(args.input_file):
+        logging.error("Input file is required and must be a valid file path.")
+        sys.exit(1)
+    if not args.api_root:
+        logging.error(
+            "API root is required. Set the CDA_API_ROOT environment variable or use --api-root."
+        )
+        sys.exit(1)
+    if not args.api_key:
+        logging.error(
+            "API key is required. Set the CDA_API_KEY environment variable or use --api-key."
+        )
+        sys.exit(1)
+    if not args.office_id:
+        logging.error(
+            "Office ID is required. Set the OFFICE environment variable or use --office-id."
+        )
+        sys.exit(1)
+    # Setup root logger
+    logger = logging.getLogger()
+    logger.setLevel(args.log_level)
+
+    # File handler with rotation: 5 MB per file, keep 5 backups
+    file_handler = RotatingFileHandler(
+        log_path, maxBytes=5 * 1024 * 1024, backupCount=5
+    )
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    )
+    logger.addHandler(file_handler)
+
+    # Console handler
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(args.log_level)
+    console_handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    )
+    logger.addHandler(console_handler)
+
+    try:
+        file_size = os.path.getsize(args.input_file)
+        with open(args.input_file, "rb") as f:
+            file_data = f.read()
+        logging.info(f"Read file: {args.input_file} ({file_size} bytes)")
+    except Exception as e:
+        logging.error(f"Failed to read file: {e}")
+        sys.exit(1)
+
+    logging.debug("CDA_API_ROOT: " + args.api_root)
+    logging.debug("CDA_API_KEY: ***...***" + args.api_key[-6:])
+    if not args.api_root.endswith("/"):
+        args.api_root += "/"
+
+    # Establish CDA session with provided API root and key
+    api.init_session(api_root=args.api_root, api_key=args.api_key)
+
+    blob: dict[str, str] = {
+        "office-id": "SWT",
+        "id": args.output_id,
+        "media-type-id": get_media_type(args.input_file),
+        "value": base64.b64encode(file_data).decode("utf-8"),
+    }
+    # Only store description if one is provided
+    if args.description:
+        blob["description"] = args.description
+    try:
+        blobs.store_blobs(blob, fail_if_exists=False)
+        logging.info(f"Successfully stored blob with ID: {args.output_id.upper()}")
+        logging.info(
+            f"View: {args.api_root}blobs/{args.output_id.upper()}?office={args.office_id}"
+        )
+    except Exception as e:
+        logging.error(f"Failed to store blob: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    # Run when this file is executed directly
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,6 @@ comments_min_spaces_from_content = 1
 whitelines = 1
 explicit_start = false
 preserve_quotes = true
+
+[tool.poetry.scripts]
+cwms = "cwms.utils.cli.__main__:main"


### PR DESCRIPTION
This PR allows you to create and use a command line interface to call scripts through the cwms-python pip install. 

# Premise

Use cwms-python directly through the command line to do things like: store files, store timeseries, and more!

This keeps districts from having to make duplicate scripts that do something similar. 

## Examples

The PR here includes a script to store a file to the blob endpoint. It uses cwms-python's store_blob method. 

By installing with `pip install cwms-python` you would then be able to run `cwms store_file "C:\path\to\file\KEYS.lakepage.jpg" KEYS.lakepage.jpg`.

It uses args or environment variables for the rest! 

Details in the README.md or help (`cwms store_file -h`)

## Testing

We could hook this CLI into tests, but it ideally uses already tested methods.

Testing I did for this PR was to call the store_file method and have it use my existing env vars on my system to store to CDA. 


### Comments

- It would be good to review the environment variables. Make sure we agree on those. I tried to pull from existing docs/infrastructure (what is set in CWBI Dev for wmes_hourly). 

- I would like to submit other utilities and reach out to the community to see what is provided

- Do we agree on `cwms` for the command, or should it be `cwms-python`?

- To enable this was very minimal. I opted to go `cwms <script>` instead of `cwms-script1` or `cmws-script2`. This makes it dynamic so you only need to add a `.py` file to `cwms/utils/cli` for future scripts!

