### PR TITLE
Multithread timeseries

### DIFF
--- a/cwms/catalog/catalog.py
+++ b/cwms/catalog/catalog.py
@@ -159,8 +159,8 @@ def get_ts_extents(ts_id: str, office_id: str) -> Tuple[datetime, datetime, date
 
     times = cwms_cat[cwms_cat.name == ts_id].extents.values[0][0]
 
-    earliest_time = pd.to_datetime(times['earliest-time'])
-    latest_time = pd.to_datetime(times['latest-time'])
-    last_update = pd.to_datetime(times['last-update'])
+    earliest_time = pd.to_datetime(times["earliest-time"])
+    latest_time = pd.to_datetime(times["latest-time"])
+    last_update = pd.to_datetime(times["last-update"])
 
     return earliest_time, latest_time, last_update

--- a/cwms/catalog/catalog.py
+++ b/cwms/catalog/catalog.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional, Tuple
 
-from dateutil import parser
+import pandas as pd
 
 import cwms.api as api
 from cwms.cwms_types import Data
@@ -156,13 +156,11 @@ def get_ts_extents(ts_id: str, office_id: str) -> Tuple[datetime, datetime, date
         page_size=500,
         include_extents=True,
     ).df
-    earliest_time = parser.isoparse(
-        cwms_cat[cwms_cat.name == ts_id].extents.values[0][0]["earliest-time"]
-    )
-    latest_time = parser.isoparse(
-        cwms_cat[cwms_cat.name == ts_id].extents.values[0][0]["latest-time"]
-    )
-    last_update = parser.isoparse(
-        cwms_cat[cwms_cat.name == ts_id].extents.values[0][0]["last-update"]
-    )
+
+    times = cwms_cat[cwms_cat.name == ts_id].extents.values[0][0]
+
+    earliest_time = pd.to_datetime(times['earliest-time'])
+    latest_time = pd.to_datetime(times['latest-time'])
+    last_update = pd.to_datetime(times['last-update'])
+
     return earliest_time, latest_time, last_update

--- a/cwms/catalog/catalog.py
+++ b/cwms/catalog/catalog.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from datetime import datetime
+from typing import Optional, Tuple
 
 from dateutil import parser
 
@@ -134,7 +135,7 @@ def get_timeseries_catalog(
     return Data(response, selector="entries")
 
 
-def get_ts_extents(ts_id: str, office_id: str):
+def get_ts_extents(ts_id: str, office_id: str) -> Tuple[datetime, datetime, datetime]:
     """Retrieves earliest extent, latest extent, and last update via cwms.get_timeseries_catalog
 
     Parameters

--- a/cwms/catalog/catalog.py
+++ b/cwms/catalog/catalog.py
@@ -134,7 +134,7 @@ def get_timeseries_catalog(
     return Data(response, selector="entries")
 
 
-def get_ts_extents(ts_id=str, office_id=str):
+def get_ts_extents(ts_id: str, office_id: str):
     """Retrieves earliest extent, latest extent, and last update via cwms.get_timeseries_catalog
 
     Parameters

--- a/cwms/catalog/catalog.py
+++ b/cwms/catalog/catalog.py
@@ -1,9 +1,9 @@
 from typing import Optional
 
+from dateutil import parser
+
 import cwms.api as api
 from cwms.cwms_types import Data
-
-from dateutil import parser
 
 
 def get_locations_catalog(

--- a/cwms/timeseries/timeseries.py
+++ b/cwms/timeseries/timeseries.py
@@ -1,8 +1,8 @@
 import concurrent.futures
-from datetime import datetime, timedelta, timezone
 import math
 import time
-from typing import Dict, Any, Optional
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
 
 import pandas as pd
 from pandas import DataFrame


### PR DESCRIPTION
Hi Guys,

Here's a first crack at adding multithreading.

1. Multi-threading to get_timeseries

- The function defaults to multi-threading and defaults to 20 threads and will chunk data by 14 days (assuming 15 minute data). It uses a helper function get_ts_extents from the catalog to check the extents of the timeseries to prevent requesting data for times outside the extents.

2. Multi-threading to store_timeseries

- The function defaults to multi-threading and defaults to 20 threads and will chunk data by 700 values (~14 days of 15 minute data). If it fails to store, it will start to backoff on how quickly it attempts to store.

Feel free to pull and make your own changes. I used a chatbot to help with a lot of it, so the code isn't very elegant but it works (although i"m sure there's improvements to be had). It seems pretty verbose for what is.

Using the local CDA, I was able to get a 6 min non-threaded call to 20 seconds. On the national instances the performance is much worse, but I think there may be some server limiting and performance issues on those.

I imaging we would want some tests for this, but I thought it would be good to get some input first.