### PR TITLE
fix typo in location_group_df_to_json

### DIFF
--- a/cwms/locations/location_groups.py
+++ b/cwms/locations/location_groups.py
@@ -134,7 +134,7 @@ def location_group_df_to_json(
     # Replace NaN with None for optional columns
     for column in optional_columns:
         if column in df.columns:
-            data[column] = df[column].where(pd.notnull(df[column]), None)
+            df[column] = df[column].where(pd.notnull(df[column]), None)
 
     # Build the list of time-series entries
     assigned_locs = df.apply(


### PR DESCRIPTION
I think this typo was preventing it from being imported when it was compiled. I was trying to set the json column instead of the df column. I compiled and tested the import locally and it worked, but will test again once on pypi.