### PR TITLE
270 enforce line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.bat]
+end_of_line = crlf
+
+[*.cmd]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto eol=lf
+
+*.bat text eol=crlf
+*.cmd text eol=crlf


### PR DESCRIPTION
The .editorconfig will make it so the files *save* with specific EOL chars

the .gitattributes will make it so the files *commit* with specific EOL chars

This will happen for the entire repo. 


I also ran `git ls-files --eol` to try and see if any files needed this applied and they all look to be in order!