### PR TITLE
ci: fix main SonarCloud quality gate findings

### DIFF
--- a/.github/workflows/CDA-testing.yml
+++ b/.github/workflows/CDA-testing.yml
@@ -61,7 +61,7 @@ jobs:
 
       # Use actions-poetry to handle installation
       - name: Install Poetry and Dependencies
-        uses: abatilo/actions-poetry@v4
+        uses: abatilo/actions-poetry@0dd19c9498c3dc8728967849d0d2eae428a8a3d8 # v4
 
       # Set Poetry to use an in-project virtual environment
       - name: Configure Poetry for in-project venv
@@ -86,7 +86,7 @@ jobs:
         run: poetry run pytest tests/cda/ --doctest-modules --cov --cov-report=xml:out/coverage.xml
 
       - name: Generate Coverage Report
-        uses: irongut/CodeCoverageSummary@v1.3.0
+        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
         with:
           filename: out/coverage.xml
           format: markdown
@@ -94,7 +94,7 @@ jobs:
           badge: true
 
       - name: Generate Job Summary
-        uses: x-color/github-actions-job-summary@v0.1.1
+        uses: x-color/github-actions-job-summary@91bbfe6fb3ba53c9d0304991601cf2508e8098a2 # v0.1.1
         with:
           file: ./code-coverage-results.md
           vars: |-

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -22,8 +22,8 @@ jobs:
       # below simply check the source code and fail if they find any files that need to be
       # formatted. The code is not automatically reformatted like it is when running the
       # pre-commit hooks.
-      - uses: psf/black@stable
+      - uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e # stable
         with:
           # Specify the desired Black version
           version: "24.10.0"
-      - uses: isort/isort-action@v1
+      - uses: isort/isort-action@24d8a7a51d33ca7f36c3f23598dafa33f7071326 # v1

--- a/.github/workflows/pypi-deploy.yml
+++ b/.github/workflows/pypi-deploy.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v4
+        uses: abatilo/actions-poetry@0dd19c9498c3dc8728967849d0d2eae428a8a3d8 # v4
       - name: Install Dependencies
         env:
           POETRY_INSTALLER_ONLY_BINARY: ':all:'
@@ -91,7 +91,7 @@ jobs:
           name: package-dist
           path: dist/
       - name: Publish Distribution To PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
       - name: Sign Distribution
         uses: sigstore/gh-action-sigstore-python@790bc6befb9d733738f18d8f895854b453640ec9 # v3.5.0
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,7 +33,7 @@ jobs:
       # Unlike the code-check workflow, this job requires the dev dependencies to be
       # installed to make sure we have the necessary, tools, stub files, etc.
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v4
+        uses: abatilo/actions-poetry@0dd19c9498c3dc8728967849d0d2eae428a8a3d8 # v4
 
       - name: Cache Virtual Environment
         uses: actions/cache@v6
@@ -57,7 +57,7 @@ jobs:
         run: poetry run mypy --strict cwms/
 
       - name: Generate Coverage Report
-        uses: irongut/CodeCoverageSummary@v1.3.0
+        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
         with:
           filename: out/coverage.xml
           format: markdown
@@ -65,7 +65,7 @@ jobs:
           badge: true
 
       - name: Generate Job Summary
-        uses: x-color/github-actions-job-summary@v0.1.1
+        uses: x-color/github-actions-job-summary@91bbfe6fb3ba53c9d0304991601cf2508e8098a2 # v0.1.1
         with:
           file: ./code-coverage-results.md
           vars: |-

--- a/compose_files/sql/users.sql
+++ b/compose_files/sql/users.sql
@@ -4,14 +4,16 @@ declare
     type office_list_t is table of varchar2(16);
 
     procedure add_full_admin(p_user varchar2, p_offices office_list_t) is
+        i pls_integer := p_offices.first;
     begin
-        for i in 1 .. p_offices.count loop
+        while i is not null loop
             cwms_sec.add_cwms_user(p_user, NULL, p_offices(i));
             cwms_sec.add_user_to_group(p_user, 'All Users',        p_offices(i));
             cwms_sec.add_user_to_group(p_user, 'CWMS Users',       p_offices(i));
             cwms_sec.add_user_to_group(p_user, 'TS ID Creator',    p_offices(i));
             cwms_sec.add_user_to_group(p_user, 'CWMS User Admins', p_offices(i));
             cwms_sec.add_user_to_group(p_user, 'CWMS PD Users',    p_offices(i));
+            i := p_offices.next(i);
         end loop;
     end;
 begin

--- a/tests/cda/levels/location_levels_cda_test.py
+++ b/tests/cda/levels/location_levels_cda_test.py
@@ -12,6 +12,7 @@ import pytest
 
 import cwms.levels.location_levels as location_levels
 import cwms.locations.physical_locations as locations
+from cwms.api import ApiError
 
 # Load test location level from tests/cda/resources/location_level.json
 LEVEL_RESOURCE_PATH = Path(__file__).parent.parent / "resources" / "location_level.json"
@@ -116,7 +117,7 @@ def test_delete_loc_level():
         office_id=TEST_OFFICE,
         effective_date=temp_effective_date,
     )
-    # Try to get it, should raise or return None/empty
+    # Only a missing resource or an empty result proves deletion succeeded.
     try:
         level = location_levels.get_location_level(
             level_id=TEST_LEVEL_ID,
@@ -124,9 +125,10 @@ def test_delete_loc_level():
             effective_date=temp_effective_date,
             unit=TEST_UNIT,
         )
+    except ApiError as error:
+        assert error.response.status_code == 404
+    else:
         assert level.df.empty
-    except Exception:
-        pass
 
 
 def test_get_loc_level_ts():

--- a/tests/cda/levels/location_levels_cda_test.py
+++ b/tests/cda/levels/location_levels_cda_test.py
@@ -112,12 +112,19 @@ def test_delete_loc_level():
     data["level-date"] = temp_effective_date.isoformat()
     data["constant-value"] = 300
     location_levels.store_location_level(data)
+    created = location_levels.get_location_level(
+        level_id=TEST_LEVEL_ID,
+        office_id=TEST_OFFICE,
+        effective_date=temp_effective_date,
+        unit=TEST_UNIT,
+    )
+    assert pd.to_datetime(created.json["level-date"]) == temp_effective_date
     location_levels.delete_location_level(
         location_level_id=TEST_LEVEL_ID,
         office_id=TEST_OFFICE,
         effective_date=temp_effective_date,
     )
-    # Only a missing resource or an empty result proves deletion succeeded.
+    # CDA may return the previous effective level after this dated level is deleted.
     try:
         level = location_levels.get_location_level(
             level_id=TEST_LEVEL_ID,
@@ -128,7 +135,7 @@ def test_delete_loc_level():
     except ApiError as error:
         assert error.response.status_code == 404
     else:
-        assert level.df.empty
+        assert pd.to_datetime(level.json["level-date"]) != temp_effective_date
 
 
 def test_get_loc_level_ts():

--- a/tests/cda/levels/specified_levels_cda_test.py
+++ b/tests/cda/levels/specified_levels_cda_test.py
@@ -97,11 +97,7 @@ def test_delete_specified_level():
     specified_levels.delete_specified_level(
         specified_level_id=temp_id, office_id=TEST_OFFICE
     )
-    # Try to get it, should raise or return None/empty
-    try:
-        levels = specified_levels.get_specified_levels(
-            specified_level_mask=temp_id, office_id=TEST_OFFICE
-        )
-        assert not any(lvl.get("id") == temp_id for lvl in levels.json)
-    except Exception:
-        pass
+    levels = specified_levels.get_specified_levels(
+        specified_level_mask=temp_id, office_id=TEST_OFFICE
+    )
+    assert not any(lvl.get("id") == temp_id for lvl in levels.json)


### PR DESCRIPTION
Main's SonarCloud quality gate fails on three reliability findings and ten unpinned workflow dependencies. This fixes the reported findings without changing the runtime API.

- Let deletion assertions and unexpected API errors fail the level tests. Verify the temporary dated level exists before deleting it, then check that CDA no longer returns that effective date; CDA can legitimately fall back to the previous level. Verify deleted specified levels are absent from the returned list.
- Iterate office collections with FIRST/NEXT so database setup handles empty or sparse collections.
- Pin the six flagged third-party Actions to the commits currently referenced by their existing tags.

Validation: 98 mock/doctest tests, strict mypy, pre-commit, and actionlint pass locally. All eight normal PR checks pass, including SonarCloud, CodeQL, and Python 3.9/latest unit tests. Failure probes confirm that undeleted data, HTTP 500, and unexpected errors fail, while the previous effective level and HTTP 404 are accepted. The corrected tests pass all 80 integration tests on Python 3.9 with production CDA and production schema. The remaining combinations in the full matrix are still running: https://github.com/HydrologicEngineeringCenter/cwms-python/actions/runs/34545073336.
